### PR TITLE
Widen rails dep to allow Rails 8

### DIFF
--- a/acts_as_important.gemspec
+++ b/acts_as_important.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'acts_as_important'
-  s.version = '0.4.0'
+  s.version = '0.5.0'
   s.email = 'contact@culturecode.ca'
   s.homepage = 'http://github.com/culturecode/acts_as_important'
   s.summary = 'Allows the you track what records are important to users and why.'
@@ -8,5 +8,5 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"]
 
-  s.add_dependency "rails", ["> 4", "< 8"]
+  s.add_dependency "rails", ["> 4", "< 9"]
 end


### PR DESCRIPTION
## Summary
- Widen runtime `rails` dep from `< 8` to `< 9` so consumer apps can resolve to Rails 8.x.
- Bump version to 0.5.0.

## Test plan
- [ ] Verified via integration: `connect_engine` (which depends on this gem) runs its full system + channel spec suite green on Rails 8.1.3 with this branch path-overridden in. Gem itself has no own spec suite.
- [ ] CI runs (whatever the gem has wired up) should be green — the rails widening is a single-line gemspec change with no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)